### PR TITLE
fix: incorrect sample for client credentials

### DIFF
--- a/docs/authentication/oauth2/client-credentials.md
+++ b/docs/authentication/oauth2/client-credentials.md
@@ -12,7 +12,7 @@ A client can retrieve an access token by making a POST request to the token endp
 POST https://token.sesamy.com/oauth/token
 Content-Type: application/x-www-form-urlencoded
 
-client_id=YOUR_CLIENT_ID&client_secret=YOUR_CLIENT_SECRET&code=CODE&grant_type=client_credentials
+client_id=YOUR_CLIENT_ID&client_secret=YOUR_CLIENT_SECRET&scope=SCOPES&grant_type=client_credentials
 ```
 
 The following query properties are available:


### PR DESCRIPTION
Client credentials use SCOPE but no CODE