### PR TITLE
fix: change default mode for checkout to redirect

### DIFF
--- a/docs/news-widget/web-components/sesamy-button.md
+++ b/docs/news-widget/web-components/sesamy-button.md
@@ -75,9 +75,9 @@ By default, the item displayed in the checkout iframe that is opened when the bu
 
 There are three different flows for the checkout once the `sesamy-button` is clicked:
 
-- If the attribute `checkout-mode="redirect"`: the navigation of current window will be redirected to the checkout standalone version.
+- If the attribute `checkout-mode="redirect"` (default behavior): the navigation of current window will be redirected to the checkout standalone version.
 - If the attribute `checkout-mode="popup"` or the button is being displayed in a mobile device: The checkout is opened in a new popup.
-- If the attribute `checkout-mode="embed"` (default behavior): The checkout is opened embedded on an iframe on the website.
+- If the attribute `checkout-mode="embed"`: The checkout is opened embedded on an iframe on the website.
 
 #### Unlock Message
 

--- a/docs/news-widget/web-components/sesamy-content-container.md
+++ b/docs/news-widget/web-components/sesamy-content-container.md
@@ -45,7 +45,7 @@ The content container matches the current url against the users purchases. In cl
 
 There are two different flows for the displaying the locked content once the `sesamy-content-conainer` is unlocked:
 
-- If the attribute `lock-mode="embedded"` (default behavior): the locked content is fetched from the content slot as in the example above.
+- If the attribute `lock-mode="embed"` (default behavior): the locked content is fetched from the content slot as in the example above.
 - If the attribute `lock-mode="signedUrl"`: the content is fetched from the publishers server using a signed url.
 - If the attribute `lock-mode="event`: an event is being emitted that could for instance be used to integrate with existing paywall solutions.
 


### PR DESCRIPTION
Changed the redirect to be the default mode for checkout.

Also changed the lock mode from embedded to embed so it's more consistent with other settings.