### PR TITLE
feat: added the listings component to the docs

### DIFF
--- a/docs/news-widget/unlocking-content.md
+++ b/docs/news-widget/unlocking-content.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Unlocking Content
 
-When a user has purchased a post the unlocked content can be displayed using the `sesamy-content-container` compont. The content can either be embedded directly on the page or fetched from the server using a signed url.
+When a user has purchased a post the unlocked content can be displayed using the `sesamy-content-container` component. The content can either be embedded directly on the page or fetched from the server using a signed url.
 
 The signed url's can for instance be shared in a order confirmation email and renders a page without any further authentication. To avoid that the signed links are being distributed that have a limited expiery.
 

--- a/docs/news-widget/web-components/sesamy-content-listing.md
+++ b/docs/news-widget/web-components/sesamy-content-listing.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 9
+---
+
+# sesamy-content-listing
+
+The content listings component is used for tracking which articles have been viewed in a list of articles.
+
+The components logs the following data:
+
+- The url of the article
+- The x and y offset of the article
+- The time spent on the page before the article was viewed
+
+It only wraps the html of an article listing without affecting the rendering.
+
+## Usage
+
+### Basic usage
+
+```html
+<html>
+  <head></head>
+  <body>
+    <sesamy-content-listing item-src="https://example.com/article">
+      <div>The article</div>
+    </sesamy-content-listing>
+
+    <script type="module">
+      import "../dist/src/sesamy-bundle.js";
+    </script>
+  </body>
+</html>
+```


### PR DESCRIPTION
Added a short description about the content-listings component.

Considering if there's an easy way to track the clicks on the listing as well? Guess we can figure that out on the server.